### PR TITLE
refine for outdoor scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,19 @@ python convert.py -s ./Data/${SESSION_NAME}/colmap --skip_matching
 
 To run the optimizer, simply use :
 ```
-python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 8 --iterations 30_000
+python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 1 --iterations 30_000
 ```
 
 for general outdoor scenes :
 ```
-python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 8 --iterations 30_000 \
---position_lr_init 0.000016 --scaling_lr 0.001
-
+# fast test
 python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 2 --iterations 30_000 \
 --position_lr_init 0.000016 --scaling_lr 0.001 --front_only
+
+# fine test
+python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 1 --iterations 60_000 \
+--position_lr_init 0.000008 --scaling_lr 0.001 --densify_until_iter 60_000 --position_lr_max_steps 60_000 \
+--densify_grad_threshold 0.0001
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 8 --ite
 --position_lr_init 0.000016 --scaling_lr 0.001
 
 python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 2 --iterations 30_000 \
---position_lr_init 0.000016 --scaling_lr 0.001 --data_device cpu
+--position_lr_init 0.000016 --scaling_lr 0.001 --front_only
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -36,25 +36,42 @@ conda env create --file environment.yml
 conda activate gaussian_splatting
 ```
 
+### Prepare session
+
+transform to colmap format:
+```
+bazel run -c opt //map/processor/output:colmap_proc_main -- \
+-map_storage_output_directory=/Alpha/Data \
+-map_storage_input_directories=/mnt/gz01/raw,/mnt/gz01/prod/spsg-cosplace-demos \
+-session_name=${SESSION_NAME}
+```
+
+prepare lidar pointcloud data:
+```
+bazel run -c opt //map/tools:transform_pointcloud_main -- \
+-map_storage_output_directory=/LidarMapping/data \
+-map_storage_input_directories=/mnt/gz01/prod/spsg-cosplace-demos \
+-session_name=${SESSION_NAME}
+```
+
 ### Running
 
 convert colmap built data session:
-```shell
-SESSION_NAME=VID_20230602_085920_00_011_office5
+```
 python convert.py -s ./Data/${SESSION_NAME}/colmap --skip_matching
 ```
 
 To run the optimizer, simply use :
-```shell
+```
 python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 8 --iterations 30_000
 ```
 
 for general outdoor scenes :
-```shell
+```
 python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 8 --iterations 30_000 \
 --position_lr_init 0.000016 --scaling_lr 0.001
 
-python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 2 --iterations 60_000 \
+python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 2 --iterations 30_000 \
 --position_lr_init 0.000016 --scaling_lr 0.001 --data_device cpu
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Bernhard Kerbl*, Georgios Kopanas*, Thomas Leimkühler, George Drettakis (* indi
 
 This repository contains the official authors implementation associated with the paper "3D Gaussian Splatting for Real-Time Radiance Field Rendering", which can be found [here](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/). We further provide the reference images used to create the error metrics reported in the paper, as well as recently created, pre-trained models.
 
-<a href="https://www.inria.fr/"><img style="width:25%;" src="assets/logo_inria.png"></a>
-<a href="https://univ-cotedazur.eu/"><img style="width:25%;" src="assets/logo_uca.png"></a>
-<a href="https://www.mpi-inf.mpg.de"><img style="width:25%;" src="assets/logo_mpi.png"></a>
-<a href="https://team.inria.fr/graphdeco/"> <img style="width:25%;" src="assets/logo_graphdeco.png"></a>
+<a href="https://www.inria.fr/"><img style="width:20%;" src="assets/logo_inria.png"></a>
+<a href="https://univ-cotedazur.eu/"><img style="width:20%;" src="assets/logo_uca.png"></a>
+<a href="https://www.mpi-inf.mpg.de"><img style="width:20%;" src="assets/logo_mpi.png"></a>
+<a href="https://team.inria.fr/graphdeco/"> <img style="width:20%;" src="assets/logo_graphdeco.png"></a>
 
 Abstract: *Radiance Field methods have recently revolutionized novel-view synthesis of scenes captured with multiple photos or videos. However, achieving high visual quality still requires neural networks that are costly to train and render, while recent faster methods inevitably trade off speed for quality. For unbounded and complete scenes (rather than isolated objects) and 1080p resolution rendering, no current method can achieve real-time display rates. We introduce three key elements that allow us to achieve state-of-the-art visual quality while maintaining competitive training times and importantly allow high-quality real-time (≥ 30 fps) novel-view synthesis at 1080p resolution. First, starting from sparse points produced during camera calibration, we represent the scene with 3D Gaussians that preserve desirable properties of continuous volumetric radiance fields for scene optimization while avoiding unnecessary computation in empty space; Second, we perform interleaved optimization/density control of the 3D Gaussians, notably optimizing anisotropic covariance to achieve an accurate representation of the scene; Third, we develop a fast visibility-aware rendering algorithm that supports anisotropic splatting and both accelerates training and allows realtime rendering. We demonstrate state-of-the-art visual quality and real-time rendering on several established datasets.*
 
@@ -46,13 +46,16 @@ python convert.py -s ./Data/${SESSION_NAME}/colmap --skip_matching
 
 To run the optimizer, simply use :
 ```shell
-python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 8 --iterations 60_000
+python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 8 --iterations 30_000
 ```
 
 for general outdoor scenes :
 ```shell
-python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 8 --iterations 60_000 \
+python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 8 --iterations 30_000 \
 --position_lr_init 0.000016 --scaling_lr 0.001
+
+python train.py --source_path ./Data/${SESSION_NAME}/colmap --resolution 2 --iterations 60_000 \
+--position_lr_init 0.000016 --scaling_lr 0.001 --data_device cpu
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The optimizer uses PyTorch and CUDA extensions in a Python environment to produc
 
 ### Setup
 
+**Fork to keep tracking the latest updates.**
+
 #### Local Setup
 
 create and run docker environment:

--- a/arguments/__init__.py
+++ b/arguments/__init__.py
@@ -3,7 +3,7 @@
 # GRAPHDECO research group, https://team.inria.fr/graphdeco
 # All rights reserved.
 #
-# This software is free for non-commercial, research and evaluation use 
+# This software is free for non-commercial, research and evaluation use
 # under the terms of the LICENSE.md file.
 #
 # For inquiries contact  george.drettakis@inria.fr
@@ -25,7 +25,7 @@ class ParamGroup:
                 shorthand = True
                 key = key[1:]
             t = type(value)
-            value = value if not fill_none else None 
+            value = value if not fill_none else None
             if shorthand:
                 if t == bool:
                     group.add_argument("--" + key, ("-" + key[0:1]), default=value, action="store_true")
@@ -44,7 +44,7 @@ class ParamGroup:
                 setattr(group, arg[0], arg[1])
         return group
 
-class ModelParams(ParamGroup): 
+class ModelParams(ParamGroup):
     def __init__(self, parser, sentinel=False):
         self.sh_degree = 3
         self._source_path = ""
@@ -52,6 +52,7 @@ class ModelParams(ParamGroup):
         self._images = "images"
         self._resolution = -1
         self._white_background = False
+        self.front_only = False
         self.data_device = "cuda"
         self.eval = False
         super().__init__(parser, "Loading Parameters", sentinel)

--- a/arguments/__init__.py
+++ b/arguments/__init__.py
@@ -82,7 +82,7 @@ class OptimizationParams(ParamGroup):
         self.rotation_lr = 0.001
         self.percent_dense = 0.01
         self.lambda_dssim = 0.2
-        self.densification_interval = 100
+        self.densification_interval = 200
         self.opacity_reset_interval = 3000
         self.densify_from_iter = 500
         self.densify_until_iter = 15_000

--- a/scene/__init__.py
+++ b/scene/__init__.py
@@ -11,15 +11,18 @@
 
 import os
 import random
+from random import randint
 import json
+import numpy as np
 from utils.system_utils import searchForMaxIteration
 from scene.dataset_readers import sceneLoadTypeCallbacks
 from scene.gaussian_model import GaussianModel
 from arguments import ModelParams
-from utils.camera_utils import cameraList_from_camInfos, camera_to_JSON
+from utils.camera_utils import cameraList_from_camInfos, camera_to_JSON, loadCam
 
+# the version read image from file one by one, to save memory consumption
+# refer to the original repo for the raw version
 class Scene:
-
     gaussians : GaussianModel
 
     def __init__(self, args : ModelParams, gaussians : GaussianModel, load_iteration=None, shuffle=True, resolution_scales=[1.0]):
@@ -29,6 +32,8 @@ class Scene:
         self.model_path = args.model_path
         self.loaded_iter = None
         self.gaussians = gaussians
+        self.args = args
+        self.resolution_scales = resolution_scales
 
         if load_iteration:
             if load_iteration == -1:
@@ -37,11 +42,8 @@ class Scene:
                 self.loaded_iter = load_iteration
             print("Loading trained model at iteration {}".format(self.loaded_iter))
 
-        self.train_cameras = {}
-        self.test_cameras = {}
-
         if os.path.exists(os.path.join(args.source_path, "sparse")):
-            scene_info = sceneLoadTypeCallbacks["Colmap"](args.source_path, args.images, args.eval)
+            scene_info = sceneLoadTypeCallbacks["Colmap"](args.source_path, args.images, args.eval, args.front_only)
         elif os.path.exists(os.path.join(args.source_path, "transforms_train.json")):
             print("Found transforms_train.json file, assuming Blender data set!")
             scene_info = sceneLoadTypeCallbacks["Blender"](args.source_path, args.white_background, args.eval)
@@ -67,24 +69,37 @@ class Scene:
             random.shuffle(scene_info.test_cameras)  # Multi-res consistent random shuffling
 
         self.cameras_extent = scene_info.nerf_normalization["radius"]
-
-        for resolution_scale in resolution_scales:
-            print("Loading Training Cameras")
-            self.train_cameras[resolution_scale] = cameraList_from_camInfos(scene_info.train_cameras, resolution_scale, args)
-            print("Loading Test Cameras")
-            self.test_cameras[resolution_scale] = cameraList_from_camInfos(scene_info.test_cameras, resolution_scale, args)
+        self.train_cameras = scene_info.train_cameras
+        self.test_cameras = scene_info.test_cameras
+        print("  - Load", len(self.train_cameras), "Training Cameras")
+        print("  - Load", len(self.test_cameras), "Test Cameras")
+        self.reset_train_test_ids()
 
         if self.loaded_iter:
-            self.gaussians.load_ply(os.path.join(self.model_path,
-                                                           "point_cloud",
-                                                           "iteration_" + str(self.loaded_iter),
-                                                           "point_cloud.ply"))
+            self.gaussians.load_ply(os.path.join(self.model_path, "point_cloud", "iteration_" + str(self.loaded_iter), "point_cloud.ply"))
         else:
             self.gaussians.create_from_pcd(scene_info.point_cloud, self.cameras_extent)
 
     def save(self, iteration):
         point_cloud_path = os.path.join(self.model_path, "point_cloud/iteration_{}".format(iteration))
         self.gaussians.save_ply(os.path.join(point_cloud_path, "point_cloud.ply"))
+
+    def reset_train_test_ids(self):
+        self.train_ids = {}
+        self.test_ids = {}
+        for resolution_scale in self.resolution_scales:
+            self.train_ids[resolution_scale] = np.arange(len(self.train_cameras)).tolist()
+            self.test_ids[resolution_scale] = np.arange(len(self.test_cameras)).tolist()
+
+    def popTrainCamera(self, scale=1.0):
+        current_size = len(self.train_ids[scale])
+        if current_size == 0: # reload the ids
+            self.reset_train_test_ids()
+            current_size = len(self.train_ids[scale])
+
+        train_id = self.train_ids[scale].pop(randint(0, current_size - 1))
+        camera = self.train_cameras[train_id]
+        return loadCam(self.args, train_id, camera, scale) # read image from file
 
     def getTrainCameras(self, scale=1.0):
         return self.train_cameras[scale]

--- a/scene/__init__.py
+++ b/scene/__init__.py
@@ -101,8 +101,11 @@ class Scene:
         camera = self.train_cameras[train_id]
         return loadCam(self.args, train_id, camera, scale) # read image from file
 
-    def getTrainCameras(self, scale=1.0):
-        return self.train_cameras[scale]
+    def getTestSize(self):
+        return len(self.test_cameras)
 
-    def getTestCameras(self, scale=1.0):
-        return self.test_cameras[scale]
+    # def getTrainCameras(self, scale=1.0):
+    #     return self.train_cameras[scale]
+    #
+    # def getTestCameras(self, scale=1.0):
+    #     return self.test_cameras[scale]

--- a/scene/__init__.py
+++ b/scene/__init__.py
@@ -35,6 +35,7 @@ class Scene:
         self.gaussians = gaussians
         self.args = args
         self.resolution_scales = resolution_scales
+        self.iteration_offset = 0
 
         if load_iteration is not None:
             if load_iteration == -1:
@@ -42,6 +43,7 @@ class Scene:
             else:
                 self.loaded_iter = load_iteration
             if self.loaded_iter is not None:
+                self.iteration_offset = self.loaded_iter
                 print("Loading trained model at iteration {}".format(self.loaded_iter))
 
         if os.path.exists(os.path.join(args.source_path, "sparse")):
@@ -86,7 +88,7 @@ class Scene:
 
 
     def save(self, iteration):
-        point_cloud_path = os.path.join(self.model_path, "point_cloud/iteration_{}".format(iteration))
+        point_cloud_path = os.path.join(self.model_path, "point_cloud/iteration_{}".format(iteration + self.iteration_offset))
         self.gaussians.save_ply(os.path.join(point_cloud_path, "point_cloud.ply"))
 
     def reset_train_test_ids(self):

--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -109,11 +109,9 @@ def readColmapCameras(cam_extrinsics, cam_intrinsics, images_folder, front_only)
 
         image_path = os.path.join(images_folder, extr.name)
         image_name = extr.name
-        # image_path = os.path.join(images_folder, os.path.basename(extr.name))
-        # image_name = os.path.basename(image_path).split(".")[0]
-        image = Image.open(image_path)
+        # image = Image.open(image_path)
 
-        cam_info = CameraInfo(uid=uid, R=R, T=T, FovY=FovY, FovX=FovX, image=image,
+        cam_info = CameraInfo(uid=uid, R=R, T=T, FovY=FovY, FovX=FovX, image=None,
                               image_path=image_path, image_name=image_name, width=width, height=height)
         cam_infos.append(cam_info)
     sys.stdout.write('\n')

--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -65,15 +65,22 @@ def getNerfppNorm(cam_info):
 
     return {"translate": translate, "radius": radius}
 
-def readColmapCameras(cam_extrinsics, cam_intrinsics, images_folder):
+def readColmapCameras(cam_extrinsics, cam_intrinsics, images_folder, front_only):
+    if front_only :
+        print("  - Read camera_front only.")
     cam_infos = []
     for idx, key in enumerate(cam_extrinsics):
         sys.stdout.write('\r')
         # the exact output you're looking for:
-        sys.stdout.write("Reading camera {}/{}".format(idx+1, len(cam_extrinsics)))
+        sys.stdout.write("  - Reading camera {}/{}".format(idx+1, len(cam_extrinsics)))
         sys.stdout.flush()
 
         extr = cam_extrinsics[key]
+
+        # use front camera only
+        if front_only and extr.name.find('front') < 0:
+            continue
+
         intr = cam_intrinsics[extr.camera_id]
         height = intr.height
         width = intr.width
@@ -149,7 +156,8 @@ def readPointcloud(path, save_ply_path):
     return True
 
 
-def readColmapSceneInfo(path, images, eval, llffhold=8):
+def readColmapSceneInfo(path, images, eval, front_only=False, llffhold=8):
+    print("Read Colmap model from", path)
     try:
         cameras_extrinsic_file = os.path.join(path, "sparse/0", "images.bin")
         cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.bin")
@@ -162,7 +170,8 @@ def readColmapSceneInfo(path, images, eval, llffhold=8):
         cam_intrinsics = read_intrinsics_text(cameras_intrinsic_file)
 
     reading_dir = "images" if images == None else images
-    cam_infos_unsorted = readColmapCameras(cam_extrinsics=cam_extrinsics, cam_intrinsics=cam_intrinsics, images_folder=os.path.join(path, reading_dir))
+    cam_infos_unsorted = readColmapCameras(cam_extrinsics=cam_extrinsics, cam_intrinsics=cam_intrinsics,
+                                           images_folder=os.path.join(path, reading_dir), front_only=front_only)
     cam_infos = sorted(cam_infos_unsorted.copy(), key = lambda x : x.image_name)
 
     if eval:

--- a/scene/gaussian_model.py
+++ b/scene/gaussian_model.py
@@ -255,6 +255,7 @@ class GaussianModel:
         self._rotation = nn.Parameter(torch.tensor(rots, dtype=torch.float, device="cuda").requires_grad_(True))
 
         self.active_sh_degree = self.max_sh_degree
+        self.max_radii2D = torch.zeros((self.get_xyz.shape[0]), device="cuda")
 
     def replace_tensor_to_optimizer(self, tensor, name):
         optimizable_tensors = {}

--- a/scene/gaussian_model.py
+++ b/scene/gaussian_model.py
@@ -3,7 +3,7 @@
 # GRAPHDECO research group, https://team.inria.fr/graphdeco
 # All rights reserved.
 #
-# This software is free for non-commercial, research and evaluation use 
+# This software is free for non-commercial, research and evaluation use
 # under the terms of the LICENSE.md file.
 #
 # For inquiries contact  george.drettakis@inria.fr
@@ -29,7 +29,7 @@ class GaussianModel:
             actual_covariance = L @ L.transpose(1, 2)
             symm = strip_symmetric(actual_covariance)
             return symm
-        
+
         self.scaling_activation = torch.exp
         self.scaling_inverse_activation = torch.log
 
@@ -43,7 +43,7 @@ class GaussianModel:
 
     def __init__(self, sh_degree : int):
         self.active_sh_degree = 0
-        self.max_sh_degree = sh_degree  
+        self.max_sh_degree = sh_degree
         self._xyz = torch.empty(0)
         self._features_dc = torch.empty(0)
         self._features_rest = torch.empty(0)
@@ -73,19 +73,19 @@ class GaussianModel:
             self.optimizer.state_dict(),
             self.spatial_lr_scale,
         )
-    
+
     def restore(self, model_args, training_args):
-        (self.active_sh_degree, 
-        self._xyz, 
-        self._features_dc, 
+        (self.active_sh_degree,
+        self._xyz,
+        self._features_dc,
         self._features_rest,
-        self._scaling, 
-        self._rotation, 
+        self._scaling,
+        self._rotation,
         self._opacity,
-        self.max_radii2D, 
-        xyz_gradient_accum, 
+        self.max_radii2D,
+        xyz_gradient_accum,
         denom,
-        opt_dict, 
+        opt_dict,
         self.spatial_lr_scale) = model_args
         self.training_setup(training_args)
         self.xyz_gradient_accum = xyz_gradient_accum
@@ -95,25 +95,25 @@ class GaussianModel:
     @property
     def get_scaling(self):
         return self.scaling_activation(self._scaling)
-    
+
     @property
     def get_rotation(self):
         return self.rotation_activation(self._rotation)
-    
+
     @property
     def get_xyz(self):
         return self._xyz
-    
+
     @property
     def get_features(self):
         features_dc = self._features_dc
         features_rest = self._features_rest
         return torch.cat((features_dc, features_rest), dim=1)
-    
+
     @property
     def get_opacity(self):
         return self.opacity_activation(self._opacity)
-    
+
     def get_covariance(self, scaling_modifier = 1):
         return self.covariance_activation(self.get_scaling, scaling_modifier, self._rotation)
 
@@ -198,6 +198,7 @@ class GaussianModel:
         opacities = self._opacity.detach().cpu().numpy()
         scale = self._scaling.detach().cpu().numpy()
         rotation = self._rotation.detach().cpu().numpy()
+        print("  - Number of points", xyz.shape[0])
 
         dtype_full = [(attribute, 'f4') for attribute in self.construct_list_of_attributes()]
 
@@ -376,7 +377,7 @@ class GaussianModel:
         selected_pts_mask = torch.where(torch.norm(grads, dim=-1) >= grad_threshold, True, False)
         selected_pts_mask = torch.logical_and(selected_pts_mask,
                                               torch.max(self.get_scaling, dim=1).values <= self.percent_dense*scene_extent)
-        
+
         new_xyz = self._xyz[selected_pts_mask]
         new_features_dc = self._features_dc[selected_pts_mask]
         new_features_rest = self._features_rest[selected_pts_mask]

--- a/train.py
+++ b/train.py
@@ -162,6 +162,9 @@ def training_report(tb_writer, iteration, Ll1, loss, l1_loss, elapsed, testing_i
         tb_writer.add_scalar('train_loss_patches/total_loss', loss.item(), iteration)
         tb_writer.add_scalar('iter_time', elapsed, iteration)
 
+    if scene.getTestSize() == 0:
+        return
+
     # Report test and samples of training set
     if iteration in testing_iterations:
         torch.cuda.empty_cache()
@@ -203,7 +206,8 @@ if __name__ == "__main__":
     parser.add_argument('--port', type=int, default=6009)
     parser.add_argument('--debug_from', type=int, default=-1)
     parser.add_argument('--detect_anomaly', action='store_true', default=False)
-    parser.add_argument("--test_iterations", nargs="+", type=int, default=[7_000, 30_000, 60_000])
+    # parser.add_argument("--test_iterations", nargs="+", type=int, default=[7_000, 30_000, 60_000])
+    parser.add_argument("--test_iterations", nargs="+", type=int, default=[])
     parser.add_argument("--save_iterations", nargs="+", type=int, default=[7_000, 30_000, 60_000])
     parser.add_argument("--quiet", action="store_true")
     parser.add_argument("--checkpoint_iterations", nargs="+", type=int, default=[])

--- a/train.py
+++ b/train.py
@@ -10,10 +10,11 @@
 #
 
 import os
+import gc
 import torch
 from random import randint
 from utils.loss_utils import l1_loss, ssim
-from gaussian_renderer import render, network_gui
+from gaussian_renderer import render
 import sys
 from scene import Scene, GaussianModel
 from utils.general_utils import safe_state
@@ -52,22 +53,6 @@ def training(dataset, opt, pipe, testing_iterations, saving_iterations, checkpoi
     progress_bar = tqdm(range(first_iter, opt.iterations), desc="Training progress")
     first_iter += 1
     for iteration in range(first_iter, opt.iterations + 1):
-        if START_GUI:
-            if network_gui.conn == None:
-                network_gui.try_connect()
-            while network_gui.conn != None:
-                try:
-                    net_image_bytes = None
-                    custom_cam, do_training, pipe.convert_SHs_python, pipe.compute_cov3D_python, keep_alive, scaling_modifer = network_gui.receive()
-                    if custom_cam != None:
-                        net_image = render(custom_cam, gaussians, pipe, background, scaling_modifer)["render"]
-                        net_image_bytes = memoryview((torch.clamp(net_image, min=0, max=1.0) * 255).byte().permute(1, 2, 0).contiguous().cpu().numpy())
-                    network_gui.send(net_image_bytes, dataset.source_path)
-                    if do_training and ((iteration < int(opt.iterations)) or not keep_alive):
-                        break
-                except Exception as e:
-                    network_gui.conn = None
-
         iter_start.record()
 
         gaussians.update_learning_rate(iteration)
@@ -106,7 +91,8 @@ def training(dataset, opt, pipe, testing_iterations, saving_iterations, checkpoi
                 progress_bar.close()
 
             # Log and save
-            training_report(tb_writer, iteration, Ll1, loss, l1_loss, iter_start.elapsed_time(iter_end), testing_iterations, scene, render, (pipe, background))
+            training_report(tb_writer, iteration, Ll1, loss, l1_loss, iter_start.elapsed_time(iter_end),
+                            testing_iterations, scene, render, (pipe, background))
             if (iteration in saving_iterations):
                 print("\n[ITER {}] Saving Gaussians".format(iteration))
                 scene.save(iteration)
@@ -132,6 +118,13 @@ def training(dataset, opt, pipe, testing_iterations, saving_iterations, checkpoi
             if (iteration in checkpoint_iterations):
                 print("\n[ITER {}] Saving Checkpoint".format(iteration))
                 torch.save((gaussians.capture(), iteration), scene.model_path + "/chkpnt" + str(iteration) + ".pth")
+
+        # clear buffer
+        del render_pkg
+        del viewpoint_cam
+        torch.cuda.empty_cache()
+        gc.collect()
+
 
 def prepare_output_and_logger(args):
     if not args.model_path:
@@ -221,8 +214,6 @@ if __name__ == "__main__":
     safe_state(args.quiet)
 
     # Start GUI server, configure and run training
-    if START_GUI:
-        network_gui.init(args.ip, args.port)
     torch.autograd.set_detect_anomaly(args.detect_anomaly)
     training(lp.extract(args), op.extract(args), pp.extract(args), args.test_iterations, args.save_iterations, args.checkpoint_iterations, args.start_checkpoint, args.debug_from)
 

--- a/utils/camera_utils.py
+++ b/utils/camera_utils.py
@@ -3,7 +3,7 @@
 # GRAPHDECO research group, https://team.inria.fr/graphdeco
 # All rights reserved.
 #
-# This software is free for non-commercial, research and evaluation use 
+# This software is free for non-commercial, research and evaluation use
 # under the terms of the LICENSE.md file.
 #
 # For inquiries contact  george.drettakis@inria.fr
@@ -11,13 +11,17 @@
 
 from scene.cameras import Camera
 import numpy as np
+from PIL import Image
 from utils.general_utils import PILtoTorch
 from utils.graphics_utils import fov2focal
 
 WARNED = False
 
 def loadCam(args, id, cam_info, resolution_scale):
-    orig_w, orig_h = cam_info.image.size
+    image = cam_info.image
+    if cam_info.image is None:
+        image = Image.open(cam_info.image_path)
+    orig_w, orig_h = image.size
 
     if args.resolution in [1, 2, 4, 8]:
         resolution = round(orig_w/(resolution_scale * args.resolution)), round(orig_h/(resolution_scale * args.resolution))
@@ -38,7 +42,7 @@ def loadCam(args, id, cam_info, resolution_scale):
         scale = float(global_down) * float(resolution_scale)
         resolution = (int(orig_w / scale), int(orig_h / scale))
 
-    resized_image_rgb = PILtoTorch(cam_info.image, resolution)
+    resized_image_rgb = PILtoTorch(image, resolution)
 
     gt_image = resized_image_rgb[:3, ...]
     loaded_mask = None
@@ -46,8 +50,8 @@ def loadCam(args, id, cam_info, resolution_scale):
     if resized_image_rgb.shape[1] == 4:
         loaded_mask = resized_image_rgb[3:4, ...]
 
-    return Camera(colmap_id=cam_info.uid, R=cam_info.R, T=cam_info.T, 
-                  FoVx=cam_info.FovX, FoVy=cam_info.FovY, 
+    return Camera(colmap_id=cam_info.uid, R=cam_info.R, T=cam_info.T,
+                  FoVx=cam_info.FovX, FoVy=cam_info.FovY,
                   image=gt_image, gt_alpha_mask=loaded_mask,
                   image_name=cam_info.image_name, uid=id, data_device=args.data_device)
 

--- a/utils/loss_utils.py
+++ b/utils/loss_utils.py
@@ -3,7 +3,7 @@
 # GRAPHDECO research group, https://team.inria.fr/graphdeco
 # All rights reserved.
 #
-# This software is free for non-commercial, research and evaluation use 
+# This software is free for non-commercial, research and evaluation use
 # under the terms of the LICENSE.md file.
 #
 # For inquiries contact  george.drettakis@inria.fr
@@ -40,6 +40,8 @@ def ssim(img1, img2, window_size=11, size_average=True):
 
     return _ssim(img1, img2, window, window_size, channel, size_average)
 
+# Structural dissimilarity (DSSIM)
+# Structural Similarity-Based Object Tracking in Video Sequences
 def _ssim(img1, img2, window, window_size, channel, size_average=True):
     mu1 = F.conv2d(img1, window, padding=window_size // 2, groups=channel)
     mu2 = F.conv2d(img2, window, padding=window_size // 2, groups=channel)
@@ -61,4 +63,3 @@ def _ssim(img1, img2, window, window_size, channel, size_average=True):
         return ssim_map.mean()
     else:
         return ssim_map.mean(1).mean(1).mean(1)
-

--- a/utils/system_utils.py
+++ b/utils/system_utils.py
@@ -3,7 +3,7 @@
 # GRAPHDECO research group, https://team.inria.fr/graphdeco
 # All rights reserved.
 #
-# This software is free for non-commercial, research and evaluation use 
+# This software is free for non-commercial, research and evaluation use
 # under the terms of the LICENSE.md file.
 #
 # For inquiries contact  george.drettakis@inria.fr
@@ -24,5 +24,8 @@ def mkdir_p(folder_path):
             raise
 
 def searchForMaxIteration(folder):
+    if not path.isdir(folder):
+        return None
+
     saved_iters = [int(fname.split("_")[-1]) for fname in os.listdir(folder)]
     return max(saved_iters)


### PR DESCRIPTION
* Read image dynamically one by one, to save gpu/cpu memory.
* remove some duplication of data to save memory.
* adjust parameters.
* test with front camera only.

The result cpu/gpu usages are stabilized, which allow to run on less powerful GPU as well.
![Screenshot from 2023-10-13 16-36-08](https://github.com/yeliu-deepmirror/gaussian-splatting/assets/74998488/921dcf14-3ec7-4006-a949-a442b3ce3fbc)

TODOs:
* test in door scene.
* test s2 block build.
* test c++ render.